### PR TITLE
Redefine event ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.5.1] - 2020-11-03
+
+### Changed
+
+#### Library
+
+- Add `id` for the in memory event data structure;
+- Sort events by `id` in the Event Store `Postgres` and `InMemory` adapters to ensure proper event ordering;
+- Removed `updated_at` column from `events` table in the `mix incident.postgres.init` task;
+- Update documentation;
+- Update package dependencies;
+
+#### Bank Example Application
+
+- Update `events` migration to reflect changes in the `mix incident.postgres.init` task;
+
 ## [0.5.0] - 2020-10-15
 
 ### Added

--- a/examples/bank/priv/event_store_repo/migrations/20201103194159_create_events_table.exs
+++ b/examples/bank/priv/event_store_repo/migrations/20201103194159_create_events_table.exs
@@ -2,7 +2,8 @@ defmodule Bank.EventStoreRepo.Migrations.CreateEventsTable do
   use Ecto.Migration
 
   def change do
-    create table(:events) do
+    create table(:events, primary_key: false) do
+      add(:id, :bigserial, primary_key: true)
       add(:event_id, :binary_id, null: false)
       add(:aggregate_id, :string, null: false)
       add(:event_type, :string, null: false)
@@ -10,7 +11,7 @@ defmodule Bank.EventStoreRepo.Migrations.CreateEventsTable do
       add(:event_date, :utc_datetime_usec, null: false)
       add(:event_data, :map, null: false)
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(type: :utc_datetime_usec, updated_at: false)
     end
 
     create(index(:events, [:aggregate_id]))

--- a/lib/incident/event_store/in_memory_adapter.ex
+++ b/lib/incident/event_store/in_memory_adapter.ex
@@ -21,12 +21,13 @@ defmodule Incident.EventStore.InMemoryAdapter do
     __MODULE__
     |> Agent.get(& &1)
     |> Enum.filter(&(&1.aggregate_id == aggregate_id))
-    |> Enum.reverse()
+    |> Enum.sort(&(&1.id < &2.id))
   end
 
   @impl true
   def append(event) do
     persisted_event = %InMemoryEvent{
+      id: :erlang.unique_integer([:positive, :monotonic]),
       event_id: Ecto.UUID.generate(),
       aggregate_id: event.aggregate_id,
       event_type: event.__struct__ |> Module.split() |> List.last(),

--- a/lib/incident/event_store/in_memory_event.ex
+++ b/lib/incident/event_store/in_memory_event.ex
@@ -6,6 +6,7 @@ defmodule Incident.EventStore.InMemoryEvent do
   """
 
   @type t :: %__MODULE__{
+          id: pos_integer | nil,
           event_id: String.t() | nil,
           aggregate_id: String.t() | nil,
           event_type: String.t() | nil,
@@ -17,7 +18,6 @@ defmodule Incident.EventStore.InMemoryEvent do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @primary_key false
   embedded_schema do
     field(:event_id, :string)
     field(:aggregate_id, :string)

--- a/lib/incident/event_store/postgres_adapter.ex
+++ b/lib/incident/event_store/postgres_adapter.ex
@@ -28,13 +28,14 @@ defmodule Incident.EventStore.PostgresAdapter do
 
   @impl Incident.EventStore.Adapter
   def get(aggregate_id) do
-    # credo:disable-for-lines:6
-    from(
-      e in Event,
-      where: e.aggregate_id == ^aggregate_id,
-      order_by: [asc: e.event_date]
-    )
-    |> repo().all()
+    query =
+      from(
+        e in Event,
+        where: e.aggregate_id == ^aggregate_id,
+        order_by: [asc: e.id]
+      )
+
+    repo().all(query)
   end
 
   @impl Incident.EventStore.Adapter

--- a/lib/incident/event_store/postgres_event.ex
+++ b/lib/incident/event_store/postgres_event.ex
@@ -6,14 +6,14 @@ defmodule Incident.EventStore.PostgresEvent do
   """
 
   @type t :: %__MODULE__{
+          id: pos_integer | nil,
           event_id: String.t() | nil,
           aggregate_id: String.t() | nil,
           event_type: String.t() | nil,
           version: pos_integer | nil,
           event_date: DateTime.t() | nil,
           event_data: map | nil,
-          inserted_at: DateTime.t() | nil,
-          updated_at: DateTime.t() | nil
+          inserted_at: DateTime.t() | nil
         }
 
   use Ecto.Schema
@@ -28,7 +28,7 @@ defmodule Incident.EventStore.PostgresEvent do
     field(:event_date, :utc_datetime_usec)
     field(:event_data, :map)
 
-    timestamps()
+    timestamps(updated_at: false)
   end
 
   @required_fields ~w(event_id aggregate_id event_type version event_date event_data)a

--- a/lib/mix/tasks/postgres_init.ex
+++ b/lib/mix/tasks/postgres_init.ex
@@ -69,7 +69,8 @@ defmodule Mix.Tasks.Incident.Postgres.Init do
     defmodule <%= inspect @module_name %> do
       use Ecto.Migration
       def change do
-        create table(:events) do
+        create table(:events, primary_key: false) do
+          add(:id, :bigserial, primary_key: true)
           add(:event_id, :binary_id, null: false)
           add(:aggregate_id, :string, null: false)
           add(:event_type, :string, null: false)
@@ -77,7 +78,7 @@ defmodule Mix.Tasks.Incident.Postgres.Init do
           add(:event_date, :utc_datetime_usec, null: false)
           add(:event_data, :map, null: false)
 
-          timestamps(type: :utc_datetime_usec)
+          timestamps(type: :utc_datetime_usec, updated_at: false)
         end
 
         create(index(:events, [:aggregate_id]))

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Incident.MixProject do
   def project do
     [
       app: :incident,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/support/event_store/migrations/20190823205504_add_events_table.exs
+++ b/test/support/event_store/migrations/20190823205504_add_events_table.exs
@@ -2,7 +2,8 @@ defmodule Bank.EventStoreRepo.Migrations.AddEventsTable do
   use Ecto.Migration
 
   def change do
-    create table(:events) do
+    create table(:events, primary_key: false) do
+      add(:id, :bigserial, primary_key: true)
       add(:event_id, :binary_id, null: false)
       add(:aggregate_id, :string, null: false)
       add(:event_type, :string, null: false)
@@ -10,7 +11,7 @@ defmodule Bank.EventStoreRepo.Migrations.AddEventsTable do
       add(:event_date, :utc_datetime_usec, null: false)
       add(:event_data, :map, null: false)
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(type: :utc_datetime_usec, updated_at: false)
     end
 
     create(index(:events, [:aggregate_id]))


### PR DESCRIPTION
## Description
This PR fixes #75.

### Changed

#### Library

- Add `id` for the in memory event data structure;
- Sort events by `id` in the Event Store `Postgres` and `InMemory` adapters to ensure proper event ordering;
- Removed `updated_at` column from `events` table in the `mix incident.postgres.init` task;

#### Bank Example Application

- Update `events` migration to reflect changes in the `mix incident.postgres.init` task;