### PR TITLE
Fix GitHub issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'Describe the bug in 50 characters or less'
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,12 +1,9 @@
-## Feature Request
-
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: 'Describe your feature request in 50 characters'
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**
@@ -20,30 +17,3 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
-
-## Bug Report Template
-
----
-name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
----
-
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**Additional context**
-Add any other context about the problem here.


### PR DESCRIPTION
While filing #94 I noticed that the issue templates were not quite right. Splitting the files will actually get you better issue reports and will help the submitter by guiding them with the UI:

![](https://docs.github.com/assets/images/help/issues/new-issue-page-with-multiple-templates.png)
