### PR TITLE
Use offset when generating timestamp for PG migrations to avoid conflict

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,5 @@
 [
-  {"lib/mix/tasks/postgres_init.ex", :unused_fun, 107},
+  {"lib/mix/tasks/postgres_init.ex", :unused_fun, 109},
   {":0:unknown_function Function :persistent_term.get/1 does not exist."},
   {":0:unknown_function Function :persistent_term.put/2 does not exist."}
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.6.1] - 2021-02-23
+
+### Fixed
+
+#### Library
+
+- Fix bug in the task `mix incident.postgres.init` that would generate migration timestamps that were conflicting with each other;
+
+### Changed
+
+#### Library
+
+- Update readme with missing syntax highlighting;
+- Update Github issue templates;
+- Update package dependencies;
+
 ## [0.6.0] - 2020-12-10
 
 ### Added

--- a/lib/mix/tasks/postgres_init.ex
+++ b/lib/mix/tasks/postgres_init.ex
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Incident.Postgres.Init do
     # Generates the aggregate_locks table migration
     name = "create_aggregate_locks_table"
     path = Path.relative_to(migrations_path(event_store_repo), Mix.Project.app_path())
-    file = Path.join(path, "#{timestamp()}_#{underscore(name)}.exs")
+    file = Path.join(path, "#{timestamp(1)}_#{underscore(name)}.exs")
 
     content =
       [module_name: Module.concat([event_store_repo, Migrations, camelize(name)])]
@@ -69,9 +69,11 @@ defmodule Mix.Tasks.Incident.Postgres.Init do
     """)
   end
 
-  @spec timestamp :: String.t()
-  defp timestamp do
-    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
+  @spec timestamp(non_neg_integer()) :: String.t()
+  defp timestamp(offset \\ 0) when offset >= 0 do
+    %DateTime{year: y, month: m, day: d, hour: hh, minute: mm, second: ss} =
+      DateTime.add(DateTime.utc_now(), offset, :second)
+
     "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Incident.MixProject do
   def project do
     [
       app: :incident,
-      version: "0.6.0",
+      version: "0.6.1",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
## Description
Fixes #94 where the migration timestamps were the same, conflicting with each other during `mix ecto.migrate`.

## Changes
 * [x] add `offset` argument to be passed in to better control timestamp generation;
