### PR TITLE
Store projections with proper type in in-mempory adapter

### DIFF
--- a/lib/incident/projection_store/in_memory_adapter.ex
+++ b/lib/incident/projection_store/in_memory_adapter.ex
@@ -21,7 +21,7 @@ defmodule Incident.ProjectionStore.InMemory.Adapter do
       update_in(state, [projection], fn projections ->
         case Enum.find(projections, &(&1.aggregate_id == aggregate_id)) do
           nil ->
-            [data] ++ projections
+            [struct(projection, data)] ++ projections
 
           _ ->
             Enum.reduce(projections, [], fn record, acc ->


### PR DESCRIPTION
## Description
Currently, the in-memory adapter only stores the plain map data and thus behaves differently from the Postgres adapter.

## Changes
 * [x] Cast 
 * [ ] 

## Concerns
🤷 

## Screenshots
😏 
